### PR TITLE
feat: implement ingestion data foundations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,15 @@
 
 # Database & Cache
 DATABASE_URL=postgresql://user:pass@localhost:5432/ai_chat_manager
+PACM_DATABASE_URL=
+ATTACHMENT_STORAGE_PATH=./data/attachments
 REDIS_URL=redis://localhost:6379/0
+
+# Import Pipeline
+IMPORT_PLATFORM_HINT=
+IMPORT_ALLOW_PARTIAL=false
+IMPORT_ATTACHMENT_MAX_BYTES=10485760
+IMPORT_TMP_DIR=
 
 # Model Runtime
 EMBEDDING_MODEL=BAAI/bge-m3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# ns_codex
+# Personal AI Chat Manager
+
+Local-first system for ingesting and reasoning over AI conversations from multiple platforms. This repository implements the
+phase-oriented plan documented in [docs/BUILD_PLAN.md](docs/BUILD_PLAN.md). P1 focuses on the storage and ingestion foundation
+for ChatGPT and Claude exports.
+
+## Key Capabilities (P1)
+- SQLite-backed implementation of the PostgreSQL schema described in `docs/DB_SCHEMA.sql` (scoped to ingestion tables).
+- Import pipeline with format detection, checksum deduplication, timestamp normalization, and attachment extraction.
+- Filesystem-backed attachment storage with deterministic hashing layout.
+- Python CLI (`scripts/import_conversations.py`) to normalize exports into the local database.
+- Pytest coverage verifying end-to-end normalization, dedupe handling, and metadata persistence.
+
+## Repository Structure
+- `chat_manager/` — Python package containing database helpers, ingestion parsers, and storage utilities.
+- `docs/` — Architecture, plan, and ops documentation.
+- `scripts/` — Smoke test, setup script, and ingestion CLI.
+- `tests/` — Pytest and Vitest suites; ingestion fixtures live in `tests/python/fixtures`.
+
+## Getting Started
+1. Create a virtual environment (optional but recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install test dependencies (only `pytest` required for Python stack):
+   ```bash
+   pip install -U pytest
+   pnpm install
+   ```
+3. Run the full smoke to verify everything:
+   ```bash
+   bash scripts/smoke_test.sh
+   ```
+
+## Running the Import CLI
+```bash
+scripts/import_conversations.py exports/chatgpt.json --database data/ingest.sqlite --attachments data/attachments
+```
+
+Optional arguments:
+- `--platform-hint` — choose `chatgpt` or `claude` to bypass auto-detection.
+- `--allow-partial` — continue processing additional files when one fails.
+
+The CLI creates/updates the SQLite database and attachment directory automatically. Import metadata is stored in the
+`import_jobs` and `import_files` tables for auditability.
+
+## Environment Variables
+See [docs/ENV.md](docs/ENV.md) for canonical definitions. Key variables for P1 include:
+- `DATABASE_URL` / `PACM_DATABASE_URL` — connection string for persistence (defaults to SQLite path for dev).
+- `ATTACHMENT_STORAGE_PATH` — base directory for attachment binaries.
+- `REDIS_URL` — reserved for later caching layers.
+
+## Testing
+- Python: `pytest`
+- JavaScript: `pnpm test`
+- Combined smoke: `bash scripts/smoke_test.sh`
+
+Each change should update documentation, extend tests as needed, and keep smoke + CI runs green.

--- a/chat_manager/__init__.py
+++ b/chat_manager/__init__.py
@@ -1,0 +1,13 @@
+"""Core package for Personal AI Chat Manager data foundations."""
+
+from .db import ChatDatabase
+from .storage import AttachmentStorage
+from .ingest.pipeline import ImportPipeline, ImportResult, ImportConfig
+
+__all__ = [
+    "ChatDatabase",
+    "AttachmentStorage",
+    "ImportPipeline",
+    "ImportResult",
+    "ImportConfig",
+]

--- a/chat_manager/db.py
+++ b/chat_manager/db.py
@@ -1,0 +1,343 @@
+"""SQLite-backed persistence primitives for ingestion pipeline tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+ISOFORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def _utc_now() -> str:
+    return datetime.now(tz=timezone.utc).strftime(ISOFORMAT)
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS platforms (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    api_version TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS import_jobs (
+    id TEXT PRIMARY KEY,
+    platform_name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    files_total INTEGER NOT NULL,
+    files_processed INTEGER NOT NULL,
+    error_messages TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    finished_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS import_files (
+    content_hash TEXT PRIMARY KEY,
+    job_id TEXT NOT NULL,
+    source_path TEXT NOT NULL,
+    detected_format TEXT NOT NULL,
+    imported_at TEXT NOT NULL,
+    FOREIGN KEY(job_id) REFERENCES import_jobs(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS threads (
+    id TEXT PRIMARY KEY,
+    platform_id TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    title TEXT,
+    summary TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    message_count INTEGER NOT NULL,
+    total_tokens INTEGER NOT NULL,
+    FOREIGN KEY(platform_id) REFERENCES platforms(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS threads_platform_external_idx ON threads(platform_id, external_id);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id TEXT PRIMARY KEY,
+    thread_id TEXT NOT NULL,
+    external_id TEXT,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    sequence_number INTEGER NOT NULL,
+    token_count INTEGER NOT NULL,
+    has_attachments INTEGER NOT NULL,
+    FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS messages_thread_seq_idx ON messages(thread_id, sequence_number);
+CREATE INDEX IF NOT EXISTS messages_timestamp_idx ON messages(timestamp);
+
+CREATE TABLE IF NOT EXISTS attachments (
+    id TEXT PRIMARY KEY,
+    message_id TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    file_size INTEGER NOT NULL,
+    content_hash TEXT NOT NULL,
+    storage_path TEXT NOT NULL,
+    extracted_text TEXT,
+    metadata TEXT NOT NULL,
+    FOREIGN KEY(message_id) REFERENCES messages(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS attachments_message_idx ON attachments(message_id);
+CREATE UNIQUE INDEX IF NOT EXISTS attachments_hash_idx ON attachments(content_hash);
+"""
+
+
+@dataclass
+class ImportJob:
+    id: str
+    platform_name: str
+    status: str
+    files_total: int
+    files_processed: int
+    error_messages: list[str]
+    started_at: str
+    finished_at: Optional[str]
+
+
+class ChatDatabase:
+    """Lightweight SQLite helper matching subset of blueprint schema."""
+
+    def __init__(self, path: Path | str = ":memory:") -> None:
+        self.path = Path(path) if path != ":memory:" else Path("./:memory:")
+        self._conn = sqlite3.connect(
+            str(path),
+            check_same_thread=False,
+            detect_types=sqlite3.PARSE_DECLTYPES,
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON;")
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        return self._conn
+
+    def initialize(self) -> None:
+        self._conn.executescript(SCHEMA)
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    @contextmanager
+    def transaction(self):
+        try:
+            yield
+        except Exception:
+            self._conn.rollback()
+            raise
+        else:
+            self._conn.commit()
+
+    def get_or_create_platform(self, name: str, api_version: str | None = None) -> str:
+        cur = self._conn.execute("SELECT id FROM platforms WHERE name = ?", (name,))
+        row = cur.fetchone()
+        if row:
+            platform_id = row["id"]
+            self._conn.execute(
+                "UPDATE platforms SET updated_at = ? WHERE id = ?",
+                (_utc_now(), platform_id),
+            )
+            self._conn.commit()
+            return platform_id
+        platform_id = str(uuid.uuid4())
+        now = _utc_now()
+        self._conn.execute(
+            "INSERT INTO platforms (id, name, api_version, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+            (platform_id, name, api_version, now, now),
+        )
+        self._conn.commit()
+        return platform_id
+
+    def create_job(self, platform_name: str, files_total: int) -> ImportJob:
+        job_id = str(uuid.uuid4())
+        now = _utc_now()
+        self._conn.execute(
+            """
+            INSERT INTO import_jobs (id, platform_name, status, files_total, files_processed, error_messages, started_at)
+            VALUES (?, ?, 'running', ?, 0, ?, ?)
+            """,
+            (job_id, platform_name, files_total, json.dumps([]), now),
+        )
+        self._conn.commit()
+        return ImportJob(
+            id=job_id,
+            platform_name=platform_name,
+            status="running",
+            files_total=files_total,
+            files_processed=0,
+            error_messages=[],
+            started_at=now,
+            finished_at=None,
+        )
+
+    def update_job_progress(
+        self,
+        job_id: str,
+        *,
+        files_processed: Optional[int] = None,
+        status: Optional[str] = None,
+        error_messages: Optional[Iterable[str]] = None,
+    ) -> None:
+        updates: list[str] = []
+        params: list[object] = []
+        if files_processed is not None:
+            updates.append("files_processed = ?")
+            params.append(files_processed)
+        if status is not None:
+            updates.append("status = ?")
+            params.append(status)
+        if error_messages is not None:
+            updates.append("error_messages = ?")
+            params.append(json.dumps(list(error_messages)))
+        if status in {"completed", "failed", "cancelled"}:
+            updates.append("finished_at = ?")
+            params.append(_utc_now())
+        if not updates:
+            return
+        params.append(job_id)
+        query = f"UPDATE import_jobs SET {', '.join(updates)} WHERE id = ?"
+        self._conn.execute(query, tuple(params))
+        self._conn.commit()
+
+    def record_import_file(
+        self,
+        job_id: str,
+        *,
+        content_hash: str,
+        source_path: str,
+        detected_format: str,
+    ) -> bool:
+        cur = self._conn.execute(
+            "SELECT content_hash FROM import_files WHERE content_hash = ?",
+            (content_hash,),
+        )
+        if cur.fetchone():
+            return False
+        self._conn.execute(
+            """
+            INSERT INTO import_files (content_hash, job_id, source_path, detected_format, imported_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (content_hash, job_id, source_path, detected_format, _utc_now()),
+        )
+        self._conn.commit()
+        return True
+
+    def insert_thread(
+        self,
+        *,
+        platform_id: str,
+        external_id: str,
+        title: str | None,
+        created_at: str,
+        updated_at: str,
+        message_count: int,
+        total_tokens: int,
+        summary: str | None = None,
+    ) -> str:
+        thread_id = str(uuid.uuid4())
+        self._conn.execute(
+            """
+            INSERT INTO threads (id, platform_id, external_id, title, summary, created_at, updated_at, message_count, total_tokens)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                thread_id,
+                platform_id,
+                external_id,
+                title,
+                summary,
+                created_at,
+                updated_at,
+                message_count,
+                total_tokens,
+            ),
+        )
+        self._conn.commit()
+        return thread_id
+
+    def insert_message(
+        self,
+        *,
+        thread_id: str,
+        external_id: str | None,
+        role: str,
+        content: str,
+        content_type: str,
+        timestamp: str,
+        sequence_number: int,
+        token_count: int,
+        has_attachments: bool,
+    ) -> str:
+        message_id = str(uuid.uuid4())
+        self._conn.execute(
+            """
+            INSERT INTO messages (
+                id, thread_id, external_id, role, content, content_type, timestamp, sequence_number, token_count, has_attachments
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                message_id,
+                thread_id,
+                external_id,
+                role,
+                content,
+                content_type,
+                timestamp,
+                sequence_number,
+                token_count,
+                1 if has_attachments else 0,
+            ),
+        )
+        self._conn.commit()
+        return message_id
+
+    def insert_attachment(
+        self,
+        *,
+        message_id: str,
+        filename: str,
+        mime_type: str,
+        file_size: int,
+        content_hash: str,
+        storage_path: str,
+        extracted_text: str | None,
+        metadata: dict | None,
+    ) -> str:
+        attachment_id = str(uuid.uuid4())
+        self._conn.execute(
+            """
+            INSERT INTO attachments (
+                id, message_id, filename, mime_type, file_size, content_hash, storage_path, extracted_text, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                attachment_id,
+                message_id,
+                filename,
+                mime_type,
+                file_size,
+                content_hash,
+                storage_path,
+                extracted_text,
+                json.dumps(metadata or {}),
+            ),
+        )
+        self._conn.commit()
+        return attachment_id
+

--- a/chat_manager/ingest/__init__.py
+++ b/chat_manager/ingest/__init__.py
@@ -1,0 +1,15 @@
+"""Ingestion helpers for Personal AI Chat Manager."""
+
+from .detectors import detect_format, SupportedFormat
+from .parsers import parse_chatgpt_export, parse_claude_export
+from .pipeline import ImportPipeline, ImportResult, ImportConfig
+
+__all__ = [
+    "detect_format",
+    "SupportedFormat",
+    "parse_chatgpt_export",
+    "parse_claude_export",
+    "ImportPipeline",
+    "ImportResult",
+    "ImportConfig",
+]

--- a/chat_manager/ingest/detectors.py
+++ b/chat_manager/ingest/detectors.py
@@ -1,0 +1,38 @@
+"""Format detection helpers for import pipeline."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+class SupportedFormat(str, Enum):
+    CHATGPT = "chatgpt"
+    CLAUDE = "claude"
+
+
+def detect_format(payload: dict[str, Any]) -> SupportedFormat:
+    """Detect export format based on structural hints."""
+
+    lowered_keys = {key.lower() for key in payload.keys()}
+    fingerprint = " ".join(lowered_keys)
+    if "mapping" in lowered_keys or payload.get("format", "").lower().startswith("chatgpt"):
+        return SupportedFormat.CHATGPT
+    if "chatgpt" in fingerprint:
+        return SupportedFormat.CHATGPT
+
+    type_hint = str(payload.get("type", "")).lower()
+    if "claude" in type_hint or payload.get("source", "").lower().startswith("claude"):
+        return SupportedFormat.CLAUDE
+    if "conversation_uuid" in lowered_keys or "workspace" in lowered_keys:
+        return SupportedFormat.CLAUDE
+
+    # Claude exports frequently include "anthropic" metadata.
+    meta = payload.get("meta") or {}
+    if isinstance(meta, dict):
+        combined = " ".join(str(value).lower() for value in meta.values())
+        if "claude" in combined or "anthropic" in combined:
+            return SupportedFormat.CLAUDE
+
+    raise ValueError("Unsupported export format; expected ChatGPT or Claude JSON")
+

--- a/chat_manager/ingest/parsers.py
+++ b/chat_manager/ingest/parsers.py
@@ -1,0 +1,209 @@
+"""Export format parsers producing normalized records."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from datetime import datetime, timezone
+from typing import Any, Iterable, List
+
+from ..models import (
+    NormalizedAttachment,
+    NormalizedImport,
+    NormalizedMessage,
+    NormalizedThread,
+)
+
+
+def _parse_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc)
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    if not value:
+        return datetime.now(tz=timezone.utc)
+    text = str(value).strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text).astimezone(timezone.utc)
+    except ValueError as exc:
+        raise ValueError(f"Unable to parse datetime value: {value!r}") from exc
+
+
+def _coerce_bytes(blob: Any) -> bytes:
+    if isinstance(blob, bytes):
+        return blob
+    if blob is None:
+        return b""
+    if isinstance(blob, str):
+        candidate = blob.strip()
+        if not candidate:
+            return b""
+        try:
+            return base64.b64decode(candidate, validate=True)
+        except (binascii.Error, ValueError):
+            return candidate.encode()
+    raise TypeError(f"Unsupported attachment payload: {type(blob)!r}")
+
+
+def _normalise_role(raw: Any) -> str:
+    if isinstance(raw, dict):
+        raw = raw.get("role") or raw.get("author")
+    if raw is None:
+        return "user"
+    return str(raw).strip().lower() or "user"
+
+
+def _normalise_content(payload: Any) -> str:
+    if isinstance(payload, dict):
+        if "parts" in payload and isinstance(payload["parts"], Iterable):
+            parts = [str(part) for part in payload["parts"]]
+            return "\n".join(part for part in parts if part)
+        if "text" in payload:
+            return str(payload.get("text", ""))
+        if "content" in payload:
+            return str(payload.get("content", ""))
+    if payload is None:
+        return ""
+    return str(payload)
+
+
+def parse_chatgpt_export(payload: dict[str, Any]) -> NormalizedImport:
+    conversations = payload.get("conversations") or payload.get("threads") or []
+    if not isinstance(conversations, Iterable):
+        raise ValueError("ChatGPT export missing conversations list")
+
+    threads: List[NormalizedThread] = []
+    for conversation in conversations:
+        messages_raw = conversation.get("messages") or []
+        created = _parse_datetime(
+            conversation.get("create_time")
+            or conversation.get("created_at")
+            or (messages_raw[0]["timestamp"] if messages_raw else None)
+        )
+        updated = _parse_datetime(conversation.get("update_time") or conversation.get("updated_at") or created)
+        normalized_messages: List[NormalizedMessage] = []
+        for sequence, message in enumerate(messages_raw, start=1):
+            attachments_payload = []
+            for attachment in message.get("attachments", []) or []:
+                metadata = {
+                    key: value
+                    for key, value in attachment.items()
+                    if key not in {"filename", "mime_type", "data", "base64", "content", "extracted_text"}
+                }
+                blob = (
+                    attachment.get("data")
+                    or attachment.get("base64")
+                    or attachment.get("content")
+                    or attachment.get("body")
+                )
+                attachments_payload.append(
+                    NormalizedAttachment(
+                        filename=str(attachment.get("filename") or "attachment.bin"),
+                        content=_coerce_bytes(blob),
+                        mime_type=attachment.get("mime_type"),
+                        extracted_text=attachment.get("extracted_text"),
+                        metadata=metadata,
+                    )
+                )
+            normalized_messages.append(
+                NormalizedMessage(
+                    external_id=str(message.get("id")) if message.get("id") else None,
+                    role=_normalise_role(message.get("author") or message.get("role")),
+                    content=_normalise_content(message.get("content") or message.get("text")),
+                    timestamp=_parse_datetime(message.get("timestamp") or message.get("create_time")),
+                    content_type=str(message.get("content_type") or "text"),
+                    attachments=tuple(attachments_payload),
+                )
+            )
+        threads.append(
+            NormalizedThread(
+                external_id=str(conversation.get("id") or conversation.get("conversation_id") or conversation.get("uuid")),
+                title=conversation.get("title") or conversation.get("name"),
+                created_at=created,
+                updated_at=updated,
+                messages=normalized_messages,
+            )
+        )
+    return NormalizedImport(platform_name="ChatGPT", threads=threads)
+
+
+def parse_claude_export(payload: dict[str, Any]) -> NormalizedImport:
+    conversations = payload.get("conversations") or payload.get("chats") or []
+    if not isinstance(conversations, Iterable):
+        raise ValueError("Claude export missing conversations list")
+
+    threads: List[NormalizedThread] = []
+    for conversation in conversations:
+        messages_raw = conversation.get("messages") or []
+        created = _parse_datetime(
+            conversation.get("created_at")
+            or conversation.get("created")
+            or (messages_raw[0]["timestamp"] if messages_raw else None)
+        )
+        updated = _parse_datetime(conversation.get("updated_at") or conversation.get("modified_at") or created)
+        normalized_messages: List[NormalizedMessage] = []
+        for sequence, message in enumerate(messages_raw, start=1):
+            attachments_payload = []
+            for attachment in message.get("attachments", []) or []:
+                metadata = {
+                    key: value
+                    for key, value in attachment.items()
+                    if key
+                    not in {
+                        "name",
+                        "filename",
+                        "mime_type",
+                        "data",
+                        "base64",
+                        "content",
+                        "text",
+                        "extracted_text",
+                    }
+                }
+                blob = (
+                    attachment.get("data")
+                    or attachment.get("base64")
+                    or attachment.get("body")
+                    or attachment.get("text")
+                )
+                attachments_payload.append(
+                    NormalizedAttachment(
+                        filename=str(
+                            attachment.get("filename")
+                            or attachment.get("name")
+                            or attachment.get("id")
+                            or "attachment.bin"
+                        ),
+                        content=_coerce_bytes(blob),
+                        mime_type=attachment.get("mime_type"),
+                        extracted_text=attachment.get("extracted_text"),
+                        metadata=metadata,
+                    )
+                )
+            normalized_messages.append(
+                NormalizedMessage(
+                    external_id=str(message.get("id") or message.get("uuid")) if message.get("id") or message.get("uuid") else None,
+                    role=_normalise_role(message.get("role") or message.get("speaker")),
+                    content=_normalise_content(message.get("text") or message.get("content")),
+                    timestamp=_parse_datetime(message.get("timestamp") or message.get("created_at")),
+                    content_type=str(message.get("content_type") or "text"),
+                    attachments=tuple(attachments_payload),
+                )
+            )
+        threads.append(
+            NormalizedThread(
+                external_id=str(
+                    conversation.get("uuid")
+                    or conversation.get("id")
+                    or conversation.get("conversation_uuid")
+                ),
+                title=conversation.get("name") or conversation.get("title"),
+                created_at=created,
+                updated_at=updated,
+                messages=normalized_messages,
+            )
+        )
+    return NormalizedImport(platform_name="Claude", threads=threads)
+

--- a/chat_manager/ingest/pipeline.py
+++ b/chat_manager/ingest/pipeline.py
@@ -1,0 +1,211 @@
+"""High-level ingestion pipeline orchestration."""
+
+from __future__ import annotations
+
+import json
+import mimetypes
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+from typing import Iterable, Iterator, List
+
+from ..db import ChatDatabase
+from ..models import NormalizedImport, NormalizedThread
+from ..storage import AttachmentStorage
+from .detectors import SupportedFormat, detect_format
+from .parsers import parse_chatgpt_export, parse_claude_export
+
+TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+@dataclass(slots=True)
+class ImportConfig:
+    platform_hint: SupportedFormat | None = None
+    allow_partial: bool = True
+
+
+@dataclass(slots=True)
+class ImportResult:
+    job_id: str
+    files_processed: int
+    files_skipped: int
+    threads_created: int
+    messages_created: int
+    attachments_saved: int
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def success(self) -> bool:
+        return not self.errors
+
+
+@dataclass(slots=True)
+class _LoadedPayload:
+    source: str
+    raw: bytes
+    data: dict
+
+
+class ImportPipeline:
+    """Run normalization and persistence for supported exports."""
+
+    def __init__(self, db: ChatDatabase, storage: AttachmentStorage) -> None:
+        self.db = db
+        self.storage = storage
+
+    def ingest(self, sources: Iterable[Path | str], config: ImportConfig) -> ImportResult:
+        payloads = list(self._load_sources(sources))
+        job = self.db.create_job(
+            (config.platform_hint.value if config.platform_hint else "auto"),
+            len(payloads),
+        )
+
+        processed = skipped = threads_created = messages_created = attachments_saved = 0
+        errors: List[str] = []
+
+        for payload in payloads:
+            content_hash = sha256(payload.raw).hexdigest()
+            try:
+                fmt = config.platform_hint or detect_format(payload.data)
+            except ValueError as exc:
+                errors.append(f"{payload.source}: {exc}")
+                if not config.allow_partial:
+                    break
+                else:
+                    continue
+
+            recorded = self.db.record_import_file(
+                job.id,
+                content_hash=content_hash,
+                source_path=payload.source,
+                detected_format=fmt.value,
+            )
+            if not recorded:
+                skipped += 1
+                self.db.update_job_progress(job.id, files_processed=processed + skipped)
+                continue
+
+            try:
+                normalized = self._normalize(fmt, payload.data)
+            except Exception as exc:  # noqa: BLE001 - bubble up to caller optionally
+                errors.append(f"{payload.source}: {exc}")
+                if not config.allow_partial:
+                    break
+                else:
+                    continue
+
+            processed += 1
+            stats = self._persist(normalized)
+            threads_created += stats[0]
+            messages_created += stats[1]
+            attachments_saved += stats[2]
+            self.db.update_job_progress(job.id, files_processed=processed + skipped)
+
+        final_status = "completed" if not errors else ("failed" if processed == 0 else "completed_with_warnings")
+        self.db.update_job_progress(job.id, status=final_status, error_messages=errors)
+        return ImportResult(
+            job_id=job.id,
+            files_processed=processed,
+            files_skipped=skipped,
+            threads_created=threads_created,
+            messages_created=messages_created,
+            attachments_saved=attachments_saved,
+            errors=errors,
+        )
+
+    def _normalize(self, fmt: SupportedFormat, data: dict) -> NormalizedImport:
+        if fmt is SupportedFormat.CHATGPT:
+            return parse_chatgpt_export(data)
+        if fmt is SupportedFormat.CLAUDE:
+            return parse_claude_export(data)
+        raise ValueError(f"Unsupported format: {fmt}")
+
+    def _persist(self, normalized: NormalizedImport) -> tuple[int, int, int]:
+        platform_id = self.db.get_or_create_platform(normalized.platform_name)
+        thread_count = message_count = attachment_count = 0
+        for thread in normalized.threads:
+            thread_count += 1
+            message_count += thread.message_count()
+            attachment_count += self._persist_thread(platform_id, thread)
+        return thread_count, message_count, attachment_count
+
+    def _persist_thread(self, platform_id: str, thread: NormalizedThread) -> int:
+        created_at = self._format_datetime(thread.created_at)
+        updated_at = self._format_datetime(thread.updated_at)
+        thread_id = self.db.insert_thread(
+            platform_id=platform_id,
+            external_id=thread.external_id,
+            title=thread.title,
+            created_at=created_at,
+            updated_at=updated_at,
+            message_count=thread.message_count(),
+            total_tokens=thread.total_tokens(),
+        )
+        attachments_saved = 0
+        for sequence, message in enumerate(thread.messages, start=1):
+            message_id = self.db.insert_message(
+                thread_id=thread_id,
+                external_id=message.external_id,
+                role=message.role,
+                content=message.content,
+                content_type=message.content_type,
+                timestamp=self._format_datetime(message.timestamp),
+                sequence_number=sequence,
+                token_count=message.token_estimate(),
+                has_attachments=bool(message.attachments),
+            )
+            for attachment in message.attachments:
+                mime_type = attachment.mime_type or mimetypes.guess_type(attachment.filename)[0] or "application/octet-stream"
+                content_hash, path = self.storage.persist(message_id, attachment)
+                self.db.insert_attachment(
+                    message_id=message_id,
+                    filename=attachment.filename,
+                    mime_type=mime_type,
+                    file_size=len(attachment.content),
+                    content_hash=content_hash,
+                    storage_path=str(path),
+                    extracted_text=attachment.extracted_text,
+                    metadata=attachment.metadata,
+                )
+                attachments_saved += 1
+        return attachments_saved
+
+    def _load_sources(self, sources: Iterable[Path | str]) -> Iterator[_LoadedPayload]:
+        for source in sources:
+            path = Path(source)
+            if path.is_dir():
+                for child in sorted(path.iterdir()):
+                    yield from self._load_sources([child])
+                continue
+            if zipfile.is_zipfile(path):
+                with zipfile.ZipFile(path) as archive:
+                    for name in archive.namelist():
+                        if not name.lower().endswith((".json", ".jsonl", ".ndjson")):
+                            continue
+                        raw = archive.read(name)
+                        yield from self._decode_raw(raw, f"{path}::{name}")
+                continue
+            raw = path.read_bytes()
+            yield from self._decode_raw(raw, str(path))
+
+    def _decode_raw(self, raw: bytes, source: str) -> Iterator[_LoadedPayload]:
+        text = raw.decode("utf-8")
+        if source.lower().endswith((".jsonl", ".ndjson")):
+            for idx, line in enumerate(text.splitlines(), start=1):
+                line_text = line.strip()
+                if not line_text:
+                    continue
+                data = json.loads(line_text)
+                yield _LoadedPayload(source=f"{source}#L{idx}", raw=line_text.encode(), data=data)
+        else:
+            data = json.loads(text)
+            yield _LoadedPayload(source=source, raw=raw, data=data)
+
+    @staticmethod
+    def _format_datetime(value: datetime) -> str:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).strftime(TIMESTAMP_FORMAT)
+

--- a/chat_manager/models.py
+++ b/chat_manager/models.py
@@ -1,0 +1,66 @@
+"""Dataclasses representing canonical ingestion records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Iterable, List, Sequence
+
+
+@dataclass(slots=True)
+class NormalizedAttachment:
+    """Attachment payload extracted during normalization."""
+
+    filename: str
+    content: bytes
+    mime_type: str | None = None
+    extracted_text: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class NormalizedMessage:
+    """Canonical message representation."""
+
+    role: str
+    content: str
+    timestamp: datetime
+    external_id: str | None = None
+    content_type: str = "text"
+    attachments: Sequence[NormalizedAttachment] = field(default_factory=tuple)
+
+    def token_estimate(self) -> int:
+        """Approximate token count using whitespace split fallback."""
+
+        stripped = self.content.strip()
+        if not stripped:
+            return 0
+        # Heuristic: tokens roughly equal to word count * 1.3 for safety.
+        words = max(1, len(stripped.split()))
+        return int(words * 1.3)
+
+
+@dataclass(slots=True)
+class NormalizedThread:
+    """Canonical conversation thread."""
+
+    external_id: str
+    title: str | None
+    created_at: datetime
+    updated_at: datetime
+    messages: List[NormalizedMessage] = field(default_factory=list)
+
+    def message_count(self) -> int:
+        return len(self.messages)
+
+    def total_tokens(self) -> int:
+        return sum(message.token_estimate() for message in self.messages)
+
+
+@dataclass(slots=True)
+class NormalizedImport:
+    """Wrapper containing normalized threads for a source export."""
+
+    platform_name: str
+    threads: Iterable[NormalizedThread]
+

--- a/chat_manager/storage.py
+++ b/chat_manager/storage.py
@@ -1,0 +1,40 @@
+"""Filesystem attachment storage utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+from .models import NormalizedAttachment
+
+
+_SAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _sanitize_filename(name: str) -> str:
+    # Drop path traversal and compress spaces
+    candidate = Path(name).name.strip()
+    if not candidate:
+        candidate = "attachment.bin"
+    cleaned = _SAFE_CHARS.sub("_", candidate)
+    return cleaned[:128]
+
+
+class AttachmentStorage:
+    """Store attachments on disk using content-hash fan-out directories."""
+
+    def __init__(self, base_path: Path) -> None:
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def persist(self, message_id: str, attachment: NormalizedAttachment) -> tuple[str, Path]:
+        content_hash = hashlib.sha256(attachment.content).hexdigest()
+        shard_a, shard_b = content_hash[:2], content_hash[2:4]
+        directory = self.base_path / shard_a / shard_b / message_id
+        directory.mkdir(parents=True, exist_ok=True)
+        filename = _sanitize_filename(attachment.filename)
+        path = directory / filename
+        path.write_bytes(attachment.content)
+        return content_hash, path
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — Personal AI Chat Manager
+
+## [Unreleased]
+
+### Release Notes
+- Kickstarted Phase 1 data foundations with ChatGPT/Claude ingestion pipeline, filesystem attachment storage, and ingestion CLI.
+
+### Added
+- `chat_manager` Python package providing SQLite persistence, format detection, and normalization logic.
+- Pytest coverage for ingestion flows plus fixtures for ChatGPT and Claude exports.
+- `scripts/import_conversations.py` CLI to run imports from the command line.
+
+### Changed
+- Expanded `docs/ENV.md`, `.env.example`, and README with ingestion-focused guidance.
+- Updated `docs/CROSSREF.md`, `docs/TODO.md`, and `docs/TASKLOG.md` to reflect P1 progress.
+
+### Fixed
+- n/a (initial implementation for P1).
+

--- a/docs/CROSSREF.md
+++ b/docs/CROSSREF.md
@@ -6,15 +6,15 @@ See also: Repository Map (REPO_MAP.md) and Open Tasks (TODO.md).
 
 | Blueprint Concept | Current Coverage | Notes |
 | --- | --- | --- |
-| Layer 1: Data ingestion pipeline | Not implemented | No source or scripts for format detection, checksum dedupe, or attachment handling yet. |
-| Layer 2: Canonical data model | Not implemented | No database schema or ORM code; only placeholder pyproject config exists. |
+| Layer 1: Data ingestion pipeline | In progress | chat_manager ingestion package with format detection, checksum dedupe, attachments, and CLI import script. |
+| Layer 2: Canonical data model | In progress | SQLite schema mirrors ingestion tables with job tracking; Postgres migrations pending. |
 | Layer 3: Analysis and modeling | Not implemented | No local model orchestration or summarization code; blueprint reference only. |
 | Layer 4: Correlation and re-weaving | Not implemented | Human-in-the-loop queue, scoring, and auditing absent. |
 | Layer 5: Hybrid search and retrieval | Not implemented | No search services, indexes, or query fusion logic in repo. |
 | Local AI infrastructure (Ollama, vLLM) | Not implemented | No tooling scripts or configs for model downloads or runtime management. |
-| Import/export and interoperability | Not implemented | No CLI or API endpoints for import/export; blueprint remains theoretical. |
+| Import/export and interoperability | Partial | CLI `scripts/import_conversations.py` ingests exports; API surface still pending. |
 | Monitoring, metrics, and performance budgets | Not implemented | CI only runs sanity tests; no metrics dashboards or budgets codified. |
 | Security posture | Not implemented | SECURITY.md missing; no authn/z or hardening implemented. |
 | Phase roadmap (P1-P5) | Planned | docs/BUILD_PLAN.md links to TEST_MATRIX.md, API_SURFACE.md, DB_SCHEMA.sql with phase breakdowns. |
-| Smoke and sanity validation | Partial | scripts/smoke_test.sh runs pytest and pnpm tests; tests only check blueprint/docs presence. |
-| Environment configuration | Partial | docs/ENV.md placeholder and .env.example exist; need detailed description and runtime defaults. |
+| Smoke and sanity validation | Improved | Smoke still runs pytest/vitest; ingestion pytest suite extends coverage beyond docs checks. |
+| Environment configuration | Updated | docs/ENV.md documents all variables; .env.example now aligned with ingestion settings. |

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,48 +1,48 @@
 # Environment Configuration — Personal AI Chat Manager
 
-All runtime variables are loaded from a `.env` file (development) or the host environment (staging/production). Keep `.env.example` in sync with this table.
+All runtime variables must be documented here and reflected in `.env.example`. Values are read via `os.environ` in future phases;
+for P1 the ingestion CLI accepts command-line arguments but honours the same defaults.
 
-## Database & Cache
-| Variable | Required | Default | Description |
+## Core Persistence
+| Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `DATABASE_URL` | Yes | `postgresql://user:pass@localhost:5432/ai_chat_manager` | PostgreSQL connection string; must include pgvector extension. |
-| `REDIS_URL` | Yes | `redis://localhost:6379/0` | Redis instance used for caching, job coordination, and rate limiting. |
+| `DATABASE_URL` | Yes | `sqlite:///data/ingest.sqlite` (dev) | Connection string for the primary database. Use `postgresql://` in production with pgvector enabled. |
+| `PACM_DATABASE_URL` | Alias | `DATABASE_URL` | Canonical name used by future orchestration. Set only if you need a different DSN than `DATABASE_URL`. |
+| `ATTACHMENT_STORAGE_PATH` | Yes | `data/attachments` | Base directory for persisted attachment binaries. The ingestion CLI creates the path when missing. |
+| `REDIS_URL` | No | `redis://localhost:6379/0` | Reserved for caching/search layers coming online in P2+. Keep populated even if Redis is not yet running. |
 
-## Model Runtime
-| Variable | Required | Default | Description |
+## Import Pipeline Behaviour
+| Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `EMBEDDING_MODEL` | Yes | `BAAI/bge-m3` | Embedding model identifier loaded via Ollama/vLLM. |
-| `RERANKER_MODEL` | Yes | `BAAI/bge-reranker-v2-m3` | Cross-encoder reranker used during hybrid search. |
-| `CHAT_MODEL` | Yes | `llama3.1:70b` | Primary conversational/summarization model. |
-| `CODE_MODEL` | Yes | `codellama:34b` | Specialized model for code analysis tasks. |
+| `IMPORT_PLATFORM_HINT` | No | _auto-detect_ | Override format detection (`chatgpt` or `claude`). Mirrors the `--platform-hint` CLI flag. |
+| `IMPORT_ALLOW_PARTIAL` | No | `false` | When `true`, the importer continues after encountering a failure. Useful for bulk backfills. |
+| `IMPORT_ATTACHMENT_MAX_BYTES` | No | `10485760` (10 MiB) | Soft guardrail for attachment size; parser raises if exceeded once enforcement is wired up. |
+| `IMPORT_TMP_DIR` | No | System temp | Directory for staging extracted ZIP payloads when required. |
 
-## Correlation & Search Tuning
-| Variable | Required | Default | Description |
+## Model Runtime (Planned)
+| Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `CORRELATION_THRESHOLD` | No | `0.7` | Minimum link confidence before a thread pair is surfaced automatically. |
-| `SEMANTIC_THRESHOLD` | No | `0.8` | Cosine similarity cutoff for matching embeddings. |
-| `TEMPORAL_WINDOW_DAYS` | No | `30` | Restricts automatic correlations to conversations within N days. |
-| `MAX_BATCH_SIZE` | No | `32` | Maximum documents/messages processed per inference batch. |
-| `WORKER_CONCURRENCY` | No | `6` | Number of concurrent background workers ingesting or reweaving. |
-| `CACHE_SIZE_MB` | No | `1024` | In-memory cache budget (MB) for search/materialized snippets. |
+| `EMBEDDING_MODEL` | Yes (P2+) | `BAAI/bge-m3` | Embedding model identifier for local runtime. |
+| `RERANKER_MODEL` | Yes (P2+) | `BAAI/bge-reranker-v2-m3` | Cross-encoder for reranking search results. |
+| `CHAT_MODEL` | Yes (P2+) | `llama3.1:70b` | Primary dialogue model served by Ollama/vLLM. |
+| `CODE_MODEL` | Optional | `codellama:34b` | Code-focused assistant. |
 
 ## Network & Security
-| Variable | Required | Default | Description |
+| Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `API_KEY` | No | _(empty)_ | Optional bearer token required when exposing APIs beyond localhost. Leave unset for local-only mode. |
-| `BIND_ADDRESS` | No | `127.0.0.1` | Interface the API server listens on. Change when enabling LAN access. |
-| `CORS_ORIGINS` | No | _(empty)_ | Comma-separated origins allowed to call the API. Empty disables CORS. |
+| `API_KEY` | Optional | _empty_ | Single-user API key when exposing REST surface beyond localhost. Leave blank for local-only mode. |
+| `BIND_ADDRESS` | Yes | `127.0.0.1` | Interface binding for API/UI servers. |
+| `CORS_ORIGINS` | Optional | _empty_ | Comma-separated allow-list for browser origins. |
 
-## Feature Flags
-| Variable | Required | Default | Description |
+## Operational Flags
+| Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `ENABLE_WEBHOOKS` | No | `false` | Toggle delivery of webhook notifications for imports and correlations. |
-| `ENABLE_REWEAVE_SCHEDULER` | No | `true` | Controls auto-scheduling of correlation jobs. |
-| `BACKUP_ENABLED` | No | `true` | Enables scheduled backups for the PostgreSQL database. |
+| `ENABLE_WEBHOOKS` | No | `false` | Enables outbound webhooks for job lifecycle notifications. |
+| `ENABLE_REWEAVE_SCHEDULER` | No | `true` | Controls background correlation refresh jobs. |
+| `BACKUP_ENABLED` | No | `true` | Toggle for scheduled backups once implemented. |
+| `APP_ENV` | Yes | `development` | Environment name used for logging/metrics labelling. |
 
-## General Runtime
-| Variable | Required | Default | Description |
-| --- | --- | --- | --- |
-| `APP_ENV` | No | `development` | Logical environment label (`development`, `test`, `production`). Affects logging and diagnostics. |
-
-> Keep `.env` files out of version control. Update both this document and `.env.example` whenever configuration changes.
+### Management Notes
+- Keep `.env.example` synchronized with this document.
+- Secrets (API keys, tokens) must be injected via environment variables or secret managers—never committed to the repository.
+- Update this file whenever new configuration surfaces in code or scripts.

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -6,36 +6,32 @@ See also: Blueprint Cross-Reference (CROSSREF.md) · Open Tasks (TODO.md).
 - root/
   - .editorconfig
   - .pre-commit-config.yaml
-  - .husky/ (pre-commit hook scripts)
+  - .husky/
   - AGENTS.md
   - blueprint.md
-  - docs/ (ENV.md, REPO_MAP.md, CROSSREF.md, TODO.md, VALIDATION.md, TASKLOG.md, BRANCH_PROTECTION.md, ONBOARDING.md)
-  - package.json
-  - pnpm-lock.yaml
+  - chat_manager/
+  - docs/
+  - package.json · pnpm-lock.yaml
   - pyproject.toml
-  - scripts/ (setup.sh, smoke_test.sh)
-  - tests/ (js/sanity.test.ts, python/test_sanity.py)
-  - .github/ (CODEOWNERS, workflows/ci.yml, workflows/route-compliance.yml, PULL_REQUEST_TEMPLATE.md)
+  - scripts/
+  - tests/
+  - .github/
 
 > node_modules/, .venv/, and VCS metadata omitted for brevity.
 
 ## Inventory
 | Area | Entry | Build Tool | Configs | Tests? | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Governance | AGENTS.md; prompts.md; personas.md | n/a | n/a | n/a | Process, personas, and runbook; must stay authoritative. |
-| Product Scope | blueprint.md | n/a | n/a | Referenced by sanity tests | Single-line Markdown; contains full system blueprint defining features. |
-| Docs & Logs | docs/ | n/a | ENV.md; REPO_MAP.md; CROSSREF.md; TODO.md; VALIDATION.md; TASKLOG.md; BRANCH_PROTECTION.md; ONBOARDING.md | n/a | Discovery docs plus branch guardrails and onboarding guides. |
-| Python Tooling | pyproject.toml | pytest | pyproject.toml | tests/python/test_sanity.py | Minimal pytest config pointing to sanity tests. |
-| Node Tooling | package.json; pnpm-lock.yaml | pnpm + vitest | package.json; pnpm-lock.yaml | tests/js/sanity.test.ts | Vitest sanity check ensures docs/blueprint exist. |
-| Automation | scripts/setup.sh; scripts/smoke_test.sh | bash | scripts | Indirect via smoke tests | Setup bootstrap + smoke script running pytest/pnpm. |
-| CI/CD | .github/workflows/*.yml | GitHub Actions | ci.yml; route-compliance.yml | Runs pytest & pnpm tests; compliance enforces doc sync | Route compliance blocks code changes without plan/TODO updates. |
-| Tests | tests/ | pytest, vitest | n/a | yes | Only smoke-level sanity coverage today. |
-| Local Guardrails | .pre-commit-config.yaml; .husky/pre-commit; .editorconfig | pre-commit, husky | same | Hooks pending developer install | Developers must run `pre-commit install` and `pnpm prepare` locally. |
-| Ownership | .github/CODEOWNERS; PULL_REQUEST_TEMPLATE.md | GitHub | CODEOWNERS; PR template | n/a | CODEOWNERS + template enforce persona review & attestations. |
+| Governance | AGENTS.md; prompts.md; personas.md | n/a | n/a | n/a | Process, personas, and runbooks. |
+| Product Scope | blueprint.md | n/a | n/a | sanity tests | Single-line Markdown blueprint driving all phases. |
+| Python Backend | chat_manager/ | pytest | pyproject.toml | tests/python/test_ingestion_pipeline.py | SQLite-backed ingestion pipeline and persistence helpers. |
+| Docs & Logs | docs/ | markdown tooling | ENV.md; BUILD_PLAN.md; TEST_MATRIX.md; API_SURFACE.md; DB_SCHEMA.sql; TODO.md; VALIDATION.md; CHANGELOG.md | n/a | Planning, environment, and validation docs. |
+| Automation | scripts/ | bash/python | setup.sh; smoke_test.sh; import_conversations.py | smoke script runs pytest/pnpm | CLI helper for running ingestion from exports. |
+| Tests | tests/ | pytest; vitest | pyproject.toml; package.json | yes | Pytest covers ingestion pipeline; Vitest sanity remains for blueprint/docs presence. |
+| CI/CD | .github/workflows/*.yml | GitHub Actions | ci.yml; route-compliance.yml | yes | CI runs pytest then pnpm; route compliance enforces doc updates. |
+| Tooling | .pre-commit-config.yaml; .husky/ | pre-commit; husky | same | n/a | Local lint/test hooks (manual install). |
 
 ## Notable Observations
-- P0 planning artifacts (docs/BUILD_PLAN.md, etc.) are not present yet.
-- blueprint.md lacks line breaks, so diffs and reviews are tricky—consider reformatting when editing.
-- Branch protection must be configured in GitHub UI (see docs/BRANCH_PROTECTION.md).
-- ENV documentation is placeholder text; real env var definitions pending later phases.
-
+- Blueprint remains a single-line markdown file; normalization task is open in docs/TODO.md.
+- SECURITY.md and risk register still outstanding for later phases.
+- Future phases must replace the SQLite helper with Postgres/pgvector migrations (tracked in docs/TODO.md).

--- a/docs/TASKLOG.md
+++ b/docs/TASKLOG.md
@@ -3,3 +3,4 @@
 2025-09-16T22:52:00Z | Branch protection docs | Added BRANCH_PROTECTION.md and ONBOARDING.md; TODO updated.
 2025-09-17T01:43:53Z | P0 planning docs | Authored BUILD_PLAN, TEST_MATRIX, API_SURFACE, DB_SCHEMA; TODO updated.
 2025-09-17T02:01:54Z | Env documentation | Expanded docs/ENV.md and refreshed .env.example defaults.
+2025-09-17T02:15:48Z | P1 data foundations | Implemented ingestion pipeline, SQLite schema, CLI, pytest coverage.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,11 +8,12 @@ Live task list maintained per AGENTS.md.
 - [x] Produce P0 planning deliverables (docs/BUILD_PLAN.md, TEST_MATRIX.md, API_SURFACE.md, DB_SCHEMA.sql).
 - [ ] Normalize blueprint.md into readable multi-line format before editing.
 - [x] Flesh out docs/ENV.md with real variable definitions and align .env.example when ready.
-- [ ] Draft docs/CHANGELOG.md with Release Notes section framework.
+- [x] Draft docs/CHANGELOG.md with Release Notes section framework. (initial file added in P1)
 - [ ] Establish SECURITY.md and initial risk register before implementation.
 
 ## Discovery Follow-Ups
-- [ ] Expand test suite beyond sanity checks once features exist.
+- [ ] Stand up PostgreSQL migration tooling (Alembic) mirroring sqlite schema from P1.
+- [x] Expand test suite beyond sanity checks once features exist. (ingestion pytest coverage added)
 - [ ] Define scripts/setup.sh parity for uv and pnpm lock usage (ensure deterministic installs).
 - [ ] Outline CI enhancements (linting, smoke, future eval runners).
 - [ ] Evaluate adding PR body validation step to enforce template attestations (optional guardrail).

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,18 +1,18 @@
 # Documentation Validation
 
-Summary of gaps or contradictions discovered during repository scan.
+Summary of gaps or contradictions discovered during repository scan. Update this file whenever guardrails reveal issues that
+still need resolution.
 
-## Missing Artifacts
-- Branch protection rules enforcing required checks/reviews (configure in GitHub UI).
-- docs/BUILD_PLAN.md, docs/TEST_MATRIX.md, docs/API_SURFACE.md, docs/DB_SCHEMA.sql (required by AGENTS.md Phase P0).
-- SECURITY.md (referenced in PROMPTS.md for later phases).
-- docs/CHANGELOG.md Release Notes section (global acceptance requires it).
-- Detailed environment notes in docs/ENV.md (currently placeholder).
+## Outstanding Artifacts
+- `SECURITY.md` and initial risk register remain todo (see docs/TODO.md).
+- PostgreSQL/pgvector migration workflow (Alembic) still pending; current implementation relies on SQLite helper.
+- Blueprint formatting is still single-line, complicating diff reviews; normalization task remains open.
 
-## Inconsistencies
-- blueprint.md stored as a single physical line, making diffs and paragraph references difficult.
-- scripts/setup.sh writes .env.example but docs/ENV.md lacks matching explanations.
+## Alignment Notes
+- P0 deliverables (BUILD_PLAN, TEST_MATRIX, API_SURFACE, DB_SCHEMA) now live in `docs/` as required.
+- Environment documentation and `.env.example` are synchronized with the ingestion pipeline defaults.
+- docs/CHANGELOG.md includes Release Notes tracking for ongoing phases.
 
 ## Checks Performed
-- All markdown files enumerated (58) and docs markdown subset (1 prior to this run) reviewed.
-- Configs (package.json, pnpm-lock.yaml, pyproject.toml), CI workflow, scripts, and sanity tests inspected.
+- Reviewed markdown/doc set after P1 ingestion work.
+- Verified CI workflow still executes pytest and pnpm tests; smoke script exercises new ingestion tests.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run --reporter=dot",
+    "test": "vitest run --reporter=basic",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/scripts/import_conversations.py
+++ b/scripts/import_conversations.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+"""CLI helper to run the ingestion pipeline on export files."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from chat_manager import AttachmentStorage, ChatDatabase
+from chat_manager.ingest import ImportConfig, ImportPipeline, SupportedFormat
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "sources",
+        nargs="+",
+        help="Paths to export files or directories containing ChatGPT/Claude exports.",
+    )
+    parser.add_argument(
+        "--database",
+        default=Path("data/ingest.sqlite"),
+        type=Path,
+        help="SQLite database path for storing normalized records (default: data/ingest.sqlite).",
+    )
+    parser.add_argument(
+        "--attachments",
+        default=Path("data/attachments"),
+        type=Path,
+        help="Directory to persist attachment binaries (default: data/attachments).",
+    )
+    parser.add_argument(
+        "--platform-hint",
+        choices=[fmt.value for fmt in SupportedFormat],
+        help="Optional format hint to skip auto-detection.",
+    )
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Continue processing additional files when one fails (default: stop on first failure).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    db_path: Path = args.database
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = ChatDatabase(db_path)
+    db.initialize()
+
+    attachments_path: Path = args.attachments
+    storage = AttachmentStorage(attachments_path)
+
+    pipeline = ImportPipeline(db, storage)
+    config = ImportConfig(
+        platform_hint=SupportedFormat(args.platform_hint) if args.platform_hint else None,
+        allow_partial=args.allow_partial,
+    )
+
+    result = pipeline.ingest([Path(src) for src in args.sources], config)
+
+    if not result.success:
+        print("Import completed with issues:")
+        for error in result.errors:
+            print(f"  - {error}")
+    else:
+        print("Import completed successfully.")
+
+    print(
+        "Processed={processed} skipped={skipped} threads={threads} messages={messages} attachments={attachments}".format(
+            processed=result.files_processed,
+            skipped=result.files_skipped,
+            threads=result.threads_created,
+            messages=result.messages_created,
+            attachments=result.attachments_saved,
+        )
+    )
+
+    if not result.success:
+        print("See import_jobs table for additional metadata.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration ensuring project root is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/python/fixtures/chatgpt_sample.json
+++ b/tests/python/fixtures/chatgpt_sample.json
@@ -1,0 +1,35 @@
+{
+  "format": "chatgpt",
+  "conversations": [
+    {
+      "id": "chatcmpl-001",
+      "title": "Normalization happy path",
+      "create_time": "2024-03-01T10:00:00Z",
+      "update_time": "2024-03-01T10:05:00Z",
+      "messages": [
+        {
+          "id": "msg-001",
+          "author": {"role": "user"},
+          "content": {"parts": ["Hello Claude via ChatGPT export"]},
+          "timestamp": "2024-03-01T10:00:00Z"
+        },
+        {
+          "id": "msg-002",
+          "author": {"role": "assistant"},
+          "content": {"text": "Here is the snippet you asked for."},
+          "timestamp": "2024-03-01T10:01:00Z",
+          "content_type": "text",
+          "attachments": [
+            {
+              "filename": "notes.txt",
+              "mime_type": "text/plain",
+              "data": "SGVsbG8sIENvZGV4IQ==",
+              "extracted_text": "Hello, Codex!",
+              "metadata": {"generator": "assistant"}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/python/fixtures/claude_sample.json
+++ b/tests/python/fixtures/claude_sample.json
@@ -1,0 +1,36 @@
+{
+  "type": "claude-export",
+  "meta": {"vendor": "Anthropic"},
+  "conversations": [
+    {
+      "uuid": "conv-abc",
+      "name": "Claude ingestion",
+      "created_at": "2024-04-01T09:00:00Z",
+      "updated_at": "2024-04-01T09:10:00Z",
+      "messages": [
+        {
+          "id": "claude-msg-1",
+          "role": "user",
+          "text": "Hi Claude, can you summarize?",
+          "timestamp": "2024-04-01T09:00:00Z"
+        },
+        {
+          "id": "claude-msg-2",
+          "role": "assistant",
+          "text": "Absolutely, attaching a quick summary diagram.",
+          "timestamp": "2024-04-01T09:02:00Z",
+          "attachments": [
+            {
+              "name": "summary.png",
+              "mime_type": "image/png",
+              "base64": "U1RBQy1DT0RFWC1QSUNU",
+              "extracted_text": null,
+              "width": 400,
+              "height": 200
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/python/test_ingestion_pipeline.py
+++ b/tests/python/test_ingestion_pipeline.py
@@ -1,0 +1,101 @@
+"""Tests for ingestion pipeline normalization and persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chat_manager import AttachmentStorage, ChatDatabase
+from chat_manager.ingest import ImportConfig, ImportPipeline
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> ChatDatabase:
+    database_path = tmp_path / "ingest.sqlite"
+    db = ChatDatabase(database_path)
+    db.initialize()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture()
+def storage(tmp_path: Path) -> AttachmentStorage:
+    base = tmp_path / "attachments"
+    return AttachmentStorage(base)
+
+
+
+def test_chatgpt_ingest_creates_threads_and_attachments(db: ChatDatabase, storage: AttachmentStorage) -> None:
+    pipeline = ImportPipeline(db, storage)
+    chatgpt_path = FIXTURES / "chatgpt_sample.json"
+
+    result = pipeline.ingest([chatgpt_path], ImportConfig())
+
+    assert result.success
+    assert result.files_processed == 1
+    assert result.files_skipped == 0
+    assert result.threads_created == 1
+    assert result.messages_created == 2
+    assert result.attachments_saved == 1
+
+    cur = db.connection.execute("SELECT name FROM platforms")
+    platforms = {row["name"] for row in cur.fetchall()}
+    assert "ChatGPT" in platforms
+
+    thread_row = db.connection.execute("SELECT message_count, total_tokens FROM threads").fetchone()
+    assert thread_row["message_count"] == 2
+    assert thread_row["total_tokens"] >= 2
+
+    attachment_row = db.connection.execute(
+        "SELECT mime_type, file_size, extracted_text, storage_path FROM attachments"
+    ).fetchone()
+    assert attachment_row["mime_type"] == "text/plain"
+    assert attachment_row["file_size"] == len(b"Hello, Codex!")
+    assert attachment_row["extracted_text"] == "Hello, Codex!"
+    assert Path(attachment_row["storage_path"]).exists()
+
+    job = db.connection.execute("SELECT status, files_total, files_processed FROM import_jobs").fetchone()
+    assert job["status"] == "completed"
+    assert job["files_total"] == 1
+    assert job["files_processed"] == 1
+
+
+def test_claude_ingest_detects_format(db: ChatDatabase, storage: AttachmentStorage) -> None:
+    pipeline = ImportPipeline(db, storage)
+    claude_path = FIXTURES / "claude_sample.json"
+
+    result = pipeline.ingest([claude_path], ImportConfig())
+
+    assert result.success
+    assert result.files_processed == 1
+    assert result.threads_created == 1
+    assert result.attachments_saved == 1
+
+    attachment = db.connection.execute("SELECT mime_type, file_size FROM attachments").fetchone()
+    assert attachment["mime_type"] == "image/png"
+    assert attachment["file_size"] > 0
+
+    platform = db.connection.execute("SELECT name FROM platforms").fetchone()
+    assert platform["name"] == "Claude"
+
+
+def test_import_pipeline_skips_duplicates(db: ChatDatabase, storage: AttachmentStorage) -> None:
+    pipeline = ImportPipeline(db, storage)
+    chatgpt_path = FIXTURES / "chatgpt_sample.json"
+
+    first = pipeline.ingest([chatgpt_path], ImportConfig())
+    assert first.files_processed == 1
+
+    second = pipeline.ingest([chatgpt_path], ImportConfig())
+    assert second.files_processed == 0
+    assert second.files_skipped == 1
+    assert not second.errors
+
+    imports = db.connection.execute("SELECT COUNT(*) AS count FROM import_files").fetchone()
+    assert imports["count"] == 1
+


### PR DESCRIPTION
## Summary
- add the `chat_manager` package with SQLite schema helpers, format detectors, parsers, and the orchestration pipeline for ChatGPT/Claude exports
- introduce a filesystem-backed attachment storage utility plus `scripts/import_conversations.py` CLI for running the importer end-to-end
- extend pytest coverage with ChatGPT/Claude fixtures and refresh README/docs (.env.example, ENV.md, CROSSREF, TODO, REPO_MAP, VALIDATION, CHANGELOG) to reflect P1 data foundations

## Testing
- pytest -q
- pnpm test
- bash scripts/smoke_test.sh

## Finding Card
- **What**: Stand up the Phase 1 data-ingestion foundation including normalization pipeline, storage helpers, CLI, and tests.
- **Why**: Aligns with blueprint P1 outcomes (checksum/MIME detection, normalized storage, import job metadata) so later phases can build on a working ingestion core.
- **Risk**: Moderate — ingestion logic touches persistence and filesystem; malformed exports or large attachments could surface edge cases. Mitigated via checksum dedupe, filename sanitization, and focused fixtures.
- **Acceptance**: ChatGPT & Claude fixture imports succeed, pytest/vitest/smoke all pass, docs describe new configuration and TODOs capture outstanding Postgres/security work.


------
https://chatgpt.com/codex/tasks/task_e_68ca184c69408327a23d58172db1efb2